### PR TITLE
Revert "Speed up demo mode"

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -19,7 +19,7 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "demo_mode")] {
         /// to accelerate flow of time. should be > 0.
         /// in real time, this would be 1440 (24h * 60min/h).
-        pub const MINUTES_PER_DAY: f32 = 0.2;
+        pub const MINUTES_PER_DAY: f32 = 1.;
 
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         pub const MILLISECONDS_PER_MINUTE: u16 = (MINUTES_PER_DAY / 24. * 1000.) as u16;


### PR DESCRIPTION
Reverts solid-stack-solutions/terralux-backend#23.

A value below a certain (unknown) threshold will cause some (simulated) minutes to not be detected at random, which may cause timers to be skipped.